### PR TITLE
Add admin points panel and HL2 weapon shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# Addon-Greetings-Points
-
-This repository provides a minimal example addon that greets users and tracks
-their points. It can serve as a starting template for similar projects.
-
-## License
-
-This project is released under the [MIT License](LICENSE).
-=======
 # Addon Greetings Points
 
-This Garry's Mod addon adds a simple point system.
+Garry's Mod addon with a points system, weapon shop and admin panel.
 
-## Development
-Install Lua to run simple checks:
+## Features
+- Earn points with popup button (`+10`) and track balance.
+- Open personal points window: `points_menu`.
+- Buy Half-Life 2/Garry's Mod default weapons in shop: `points_shop`.
+- Admin points control panel: `points_admin` (admins only).
+- Chat shortcuts:
+  - `!points` — show your balance.
+  - `!shop` — open weapon shop.
+  - `!adminpoints` — open admin panel.
+
+## Development check
 ```bash
-apt-get update && apt-get install -y lua5.4
-lua -v
+luac -p lua/autorun/sv_points.lua
+luac -p lua/autorun/cl_points.lua
 ```
 
-## Usage
-
-Run the console command `points_menu` in Garry's Mod to open a small window
-displaying your current points.
+## License
+MIT, see [LICENSE](LICENSE).

--- a/lua/autorun/cl_points.lua
+++ b/lua/autorun/cl_points.lua
@@ -1,25 +1,59 @@
 if CLIENT then
 
--- Display message from server about points
+local SHOP_WEAPONS = {
+    { class = "weapon_crowbar", name = "Crowbar", price = 25 },
+    { class = "weapon_stunstick", name = "Stunstick", price = 35 },
+    { class = "weapon_pistol", name = "Pistol", price = 45 },
+    { class = "weapon_357", name = "357 Magnum", price = 80 },
+    { class = "weapon_smg1", name = "SMG", price = 90 },
+    { class = "weapon_ar2", name = "AR2", price = 120 },
+    { class = "weapon_shotgun", name = "Shotgun", price = 110 },
+    { class = "weapon_crossbow", name = "Crossbow", price = 150 },
+    { class = "weapon_frag", name = "Grenade", price = 70 },
+    { class = "weapon_rpg", name = "RPG", price = 250 }
+}
+
+local pointsLabel
+local cachedPoints = 0
+local adminScroll
+local adminFrame
+
 net.Receive("PointsResponse", function()
     local msg = net.ReadString()
     chat.AddText(Color(0, 255, 0), msg)
 end)
 
-local pointsLabel
-
 net.Receive("SendCurrentPoints", function()
-    local points = net.ReadInt(32)
+    cachedPoints = net.ReadInt(32)
+
     if IsValid(pointsLabel) then
-        pointsLabel:SetText("Ваши очки: " .. points)
+        pointsLabel:SetText("Ваши очки: " .. cachedPoints)
     else
-        chat.AddText(Color(0, 255, 0), "Ваши очки: " .. points)
+        chat.AddText(Color(0, 255, 0), "Ваши очки: " .. cachedPoints)
     end
 end)
 
+net.Receive("PointsShopPurchaseResult", function()
+    local success = net.ReadBool()
+    local _ = net.ReadString()
+    local newPoints = net.ReadInt(32)
+
+    if success then
+        cachedPoints = newPoints
+        if IsValid(pointsLabel) then
+            pointsLabel:SetText("Ваши очки: " .. cachedPoints)
+        end
+    end
+end)
+
+local function RequestCurrentPoints()
+    net.Start("RequestCurrentPoints")
+    net.SendToServer()
+end
+
 local function ShowPointsPopup()
     local frame = vgui.Create("DFrame")
-    frame:SetSize(250, 100)
+    frame:SetSize(300, 110)
     frame:Center()
     frame:SetTitle("Получить очки")
     frame:MakePopup()
@@ -27,6 +61,7 @@ local function ShowPointsPopup()
     local button = vgui.Create("DButton", frame)
     button:Dock(FILL)
     button:SetText("Получить 10 очков")
+
     function button:DoClick()
         net.Start("RequestPoints")
         net.SendToServer()
@@ -36,7 +71,7 @@ end
 
 local function ShowPointsMenu()
     local frame = vgui.Create("DFrame")
-    frame:SetSize(200, 80)
+    frame:SetSize(260, 100)
     frame:Center()
     frame:SetTitle("Мои очки")
     frame:MakePopup()
@@ -46,13 +81,192 @@ local function ShowPointsMenu()
     pointsLabel:SetContentAlignment(5)
     pointsLabel:SetText("Загрузка...")
 
-    net.Start("RequestCurrentPoints")
-    net.SendToServer()
+    RequestCurrentPoints()
 end
 
-concommand.Add("points_menu", ShowPointsMenu)
+local function ShowShopMenu()
+    local frame = vgui.Create("DFrame")
+    frame:SetSize(400, 440)
+    frame:Center()
+    frame:SetTitle("Магазин оружия")
+    frame:MakePopup()
 
--- Show popup when the local player spawns
+    local topPanel = vgui.Create("DPanel", frame)
+    topPanel:Dock(TOP)
+    topPanel:SetTall(35)
+
+    local pointsInfo = vgui.Create("DLabel", topPanel)
+    pointsInfo:Dock(FILL)
+    pointsInfo:SetContentAlignment(5)
+    pointsInfo:SetText("Ваши очки: " .. cachedPoints)
+
+    local scroll = vgui.Create("DScrollPanel", frame)
+    scroll:Dock(FILL)
+
+    for _, weapon in ipairs(SHOP_WEAPONS) do
+        local row = vgui.Create("DPanel", scroll)
+        row:Dock(TOP)
+        row:DockMargin(5, 5, 5, 0)
+        row:SetTall(40)
+
+        local label = vgui.Create("DLabel", row)
+        label:Dock(LEFT)
+        label:SetWide(220)
+        label:SetText("  " .. weapon.name .. " (" .. weapon.class .. ")")
+
+        local priceLabel = vgui.Create("DLabel", row)
+        priceLabel:Dock(LEFT)
+        priceLabel:SetWide(70)
+        priceLabel:SetContentAlignment(5)
+        priceLabel:SetText(weapon.price .. " очк.")
+
+        local buyButton = vgui.Create("DButton", row)
+        buyButton:Dock(FILL)
+        buyButton:SetText("Купить")
+
+        function buyButton:DoClick()
+            net.Start("PointsShopBuyWeapon")
+            net.WriteString(weapon.class)
+            net.SendToServer()
+
+            timer.Simple(0.15, function()
+                pointsInfo:SetText("Ваши очки: " .. cachedPoints)
+            end)
+        end
+    end
+
+    RequestCurrentPoints()
+    local timerName = "PointsShopRefreshLabel" .. frame:EntIndex()
+    timer.Create(timerName, 0.25, 0, function()
+        if not IsValid(frame) then
+            timer.Remove(timerName)
+            return
+        end
+
+        pointsInfo:SetText("Ваши очки: " .. cachedPoints)
+    end)
+end
+
+local function BuildAdminPlayerRow(parent, data, refreshFn)
+    local row = vgui.Create("DPanel", parent)
+    row:Dock(TOP)
+    row:DockMargin(5, 5, 5, 0)
+    row:SetTall(66)
+
+    local infoLabel = vgui.Create("DLabel", row)
+    infoLabel:Dock(LEFT)
+    infoLabel:SetWide(240)
+    infoLabel:SetText("  " .. data.name .. "\n  " .. data.steamid .. " | Очки: " .. data.points)
+
+    local entry = vgui.Create("DTextEntry", row)
+    entry:Dock(LEFT)
+    entry:SetWide(70)
+    entry:SetNumeric(true)
+    entry:SetText("10")
+
+    local addBtn = vgui.Create("DButton", row)
+    addBtn:Dock(LEFT)
+    addBtn:SetWide(45)
+    addBtn:SetText("+")
+    function addBtn:DoClick()
+        net.Start("PointsAdminAdjustPoints")
+        net.WriteEntity(data.entity)
+        net.WriteString("add")
+        net.WriteInt(tonumber(entry:GetValue()) or 0, 32)
+        net.SendToServer()
+        timer.Simple(0.15, refreshFn)
+    end
+
+    local subBtn = vgui.Create("DButton", row)
+    subBtn:Dock(LEFT)
+    subBtn:SetWide(45)
+    subBtn:SetText("-")
+    function subBtn:DoClick()
+        net.Start("PointsAdminAdjustPoints")
+        net.WriteEntity(data.entity)
+        net.WriteString("add")
+        net.WriteInt(-(tonumber(entry:GetValue()) or 0), 32)
+        net.SendToServer()
+        timer.Simple(0.15, refreshFn)
+    end
+
+    local setBtn = vgui.Create("DButton", row)
+    setBtn:Dock(FILL)
+    setBtn:SetText("Set")
+    function setBtn:DoClick()
+        net.Start("PointsAdminAdjustPoints")
+        net.WriteEntity(data.entity)
+        net.WriteString("set")
+        net.WriteInt(tonumber(entry:GetValue()) or 0, 32)
+        net.SendToServer()
+        timer.Simple(0.15, refreshFn)
+    end
+end
+
+local function ShowAdminMenu()
+    if not LocalPlayer():IsAdmin() then
+        chat.AddText(Color(255, 0, 0), "Только для администраторов")
+        return
+    end
+
+    local frame = vgui.Create("DFrame")
+    frame:SetSize(560, 500)
+    frame:Center()
+    frame:SetTitle("Админ панель очков")
+    frame:MakePopup()
+
+    local refreshBtn = vgui.Create("DButton", frame)
+    refreshBtn:Dock(TOP)
+    refreshBtn:SetTall(32)
+    refreshBtn:SetText("Обновить список")
+
+    local scroll = vgui.Create("DScrollPanel", frame)
+    scroll:Dock(FILL)
+    adminFrame = frame
+    adminScroll = scroll
+
+    local function requestList()
+        net.Start("PointsAdminRequestPlayers")
+        net.SendToServer()
+    end
+
+    function refreshBtn:DoClick()
+        requestList()
+    end
+
+    requestList()
+end
+
+net.Receive("PointsAdminPlayersData", function()
+    if not IsValid(adminFrame) or not IsValid(adminScroll) then
+        return
+    end
+
+    adminScroll:Clear()
+    local amount = net.ReadUInt(8)
+
+    for _index = 1, amount do
+        local entity = net.ReadEntity()
+        local name = net.ReadString()
+        local steamid = net.ReadString()
+        local points = net.ReadInt(32)
+
+        BuildAdminPlayerRow(adminScroll, {
+            entity = entity,
+            name = name,
+            steamid = steamid,
+            points = points
+        }, function()
+            net.Start("PointsAdminRequestPlayers")
+            net.SendToServer()
+        end)
+    end
+end)
+
+concommand.Add("points_menu", ShowPointsMenu)
+concommand.Add("points_shop", ShowShopMenu)
+concommand.Add("points_admin", ShowAdminMenu)
+
 hook.Add("InitPostEntity", "Points_ShowPopup", ShowPointsPopup)
 hook.Add("PlayerSpawn", "Points_ShowPopup_Spawn", function(ply)
     if ply == LocalPlayer() then

--- a/lua/autorun/sv_points.lua
+++ b/lua/autorun/sv_points.lua
@@ -1,40 +1,209 @@
 if SERVER then
 
-AddCSLuaFile("cl_points.lua")
+AddCSLuaFile("autorun/cl_points.lua")
 
 local PlayerPoints = PlayerPoints or {}
+
+local ShopWeapons = {
+    { class = "weapon_crowbar", name = "Crowbar", price = 25 },
+    { class = "weapon_stunstick", name = "Stunstick", price = 35 },
+    { class = "weapon_pistol", name = "Pistol", price = 45 },
+    { class = "weapon_357", name = "357 Magnum", price = 80 },
+    { class = "weapon_smg1", name = "SMG", price = 90 },
+    { class = "weapon_ar2", name = "AR2", price = 120 },
+    { class = "weapon_shotgun", name = "Shotgun", price = 110 },
+    { class = "weapon_crossbow", name = "Crossbow", price = 150 },
+    { class = "weapon_frag", name = "Grenade", price = 70 },
+    { class = "weapon_rpg", name = "RPG", price = 250 }
+}
 
 util.AddNetworkString("RequestPoints")
 util.AddNetworkString("PointsResponse")
 util.AddNetworkString("RequestCurrentPoints")
 util.AddNetworkString("SendCurrentPoints")
+util.AddNetworkString("PointsShopBuyWeapon")
+util.AddNetworkString("PointsShopPurchaseResult")
+util.AddNetworkString("PointsAdminRequestPlayers")
+util.AddNetworkString("PointsAdminPlayersData")
+util.AddNetworkString("PointsAdminAdjustPoints")
 
--- Handle point request from client
-net.Receive("RequestPoints", function(len, ply)
-    local sid = ply:SteamID()
-    PlayerPoints[sid] = (PlayerPoints[sid] or 0) + 10
+local function GetPoints(ply)
+    return PlayerPoints[ply:SteamID()] or 0
+end
 
-    local text = "Теперь у вас " .. PlayerPoints[sid] .. " очков"
-    net.Start("PointsResponse")
-    net.WriteString(text)
-    net.Send(ply)
-end)
+local function SetPoints(ply, amount)
+    PlayerPoints[ply:SteamID()] = math.max(0, math.floor(amount))
+end
 
--- Provide the player's current points on request
-net.Receive("RequestCurrentPoints", function(_, ply)
-    local sid = ply:SteamID()
-    local points = PlayerPoints[sid] or 0
+local function SendCurrentPoints(ply)
     net.Start("SendCurrentPoints")
-    net.WriteInt(points, 32)
+    net.WriteInt(GetPoints(ply), 32)
+    net.Send(ply)
+end
+
+local function SendPointsMessage(ply, message)
+    net.Start("PointsResponse")
+    net.WriteString(message)
+    net.Send(ply)
+end
+
+local function IsPlayerAdmin(ply)
+    return IsValid(ply) and ply:IsPlayer() and ply:IsAdmin()
+end
+
+local function FindShopWeapon(class)
+    for _, weapon in ipairs(ShopWeapons) do
+        if weapon.class == class then
+            return weapon
+        end
+    end
+
+    return nil
+end
+
+net.Receive("RequestPoints", function(_, ply)
+    SetPoints(ply, GetPoints(ply) + 10)
+    SendPointsMessage(ply, "Теперь у вас " .. GetPoints(ply) .. " очков")
+    SendCurrentPoints(ply)
+end)
+
+net.Receive("RequestCurrentPoints", function(_, ply)
+    SendCurrentPoints(ply)
+end)
+
+net.Receive("PointsShopBuyWeapon", function(_, ply)
+    local weaponClass = net.ReadString()
+    local selectedWeapon = FindShopWeapon(weaponClass)
+
+    if not selectedWeapon then
+        SendPointsMessage(ply, "Это оружие недоступно в магазине")
+        return
+    end
+
+    if not weapons.GetStored(selectedWeapon.class) then
+        SendPointsMessage(ply, "Оружие " .. selectedWeapon.name .. " отсутствует на сервере")
+        return
+    end
+
+    if ply:HasWeapon(selectedWeapon.class) then
+        SendPointsMessage(ply, "У вас уже есть " .. selectedWeapon.name)
+        return
+    end
+
+    local points = GetPoints(ply)
+    if points < selectedWeapon.price then
+        SendPointsMessage(ply, "Недостаточно очков. Нужно: " .. selectedWeapon.price)
+        return
+    end
+
+    SetPoints(ply, points - selectedWeapon.price)
+    ply:Give(selectedWeapon.class)
+
+    if not ply:HasWeapon(selectedWeapon.class) then
+        SetPoints(ply, points)
+        SendPointsMessage(ply, "Не удалось выдать оружие")
+        return
+    end
+
+    SendPointsMessage(ply, "Вы купили " .. selectedWeapon.name .. " за " .. selectedWeapon.price .. " очков")
+
+    net.Start("PointsShopPurchaseResult")
+    net.WriteBool(true)
+    net.WriteString(selectedWeapon.class)
+    net.WriteInt(GetPoints(ply), 32)
+    net.Send(ply)
+
+    SendCurrentPoints(ply)
+end)
+
+net.Receive("PointsAdminRequestPlayers", function(_, ply)
+    if not IsPlayerAdmin(ply) then
+        SendPointsMessage(ply, "Только администратор может открыть панель")
+        return
+    end
+
+    local players = player.GetAll()
+
+    net.Start("PointsAdminPlayersData")
+    net.WriteUInt(#players, 8)
+
+    for _, target in ipairs(players) do
+        net.WriteEntity(target)
+        net.WriteString(target:Nick())
+        net.WriteString(target:SteamID())
+        net.WriteInt(GetPoints(target), 32)
+    end
+
     net.Send(ply)
 end)
 
--- Chat command to show points
+net.Receive("PointsAdminAdjustPoints", function(_, ply)
+    if not IsPlayerAdmin(ply) then
+        SendPointsMessage(ply, "Недостаточно прав")
+        return
+    end
+
+    local target = net.ReadEntity()
+    local operation = net.ReadString()
+    local amount = math.floor(net.ReadInt(32))
+
+    if not IsValid(target) or not target:IsPlayer() then
+        SendPointsMessage(ply, "Игрок не найден")
+        return
+    end
+
+    if operation ~= "set" and operation ~= "add" then
+        SendPointsMessage(ply, "Неизвестная операция")
+        return
+    end
+
+    if math.abs(amount) > 100000 then
+        SendPointsMessage(ply, "Слишком большое значение")
+        return
+    end
+
+    local oldValue = GetPoints(target)
+    if operation == "set" then
+        SetPoints(target, amount)
+    else
+        SetPoints(target, oldValue + amount)
+    end
+
+    local newValue = GetPoints(target)
+    SendPointsMessage(ply, "Очки игрока " .. target:Nick() .. " изменены: " .. oldValue .. " -> " .. newValue)
+    SendPointsMessage(target, "Администратор изменил ваши очки: " .. oldValue .. " -> " .. newValue)
+
+    SendCurrentPoints(target)
+
+    net.Start("PointsAdminPlayersData")
+    net.WriteUInt(1, 8)
+    net.WriteEntity(target)
+    net.WriteString(target:Nick())
+    net.WriteString(target:SteamID())
+    net.WriteInt(newValue, 32)
+    net.Send(ply)
+end)
+
 hook.Add("PlayerSay", "PointsChatCommand", function(ply, text)
-    if string.Trim(string.lower(text)) == "!points" then
-        local sid = ply:SteamID()
-        local points = PlayerPoints[sid] or 0
-        ply:ChatPrint("Ваши очки: " .. points)
+    local command = string.Trim(string.lower(text))
+
+    if command == "!points" then
+        ply:ChatPrint("Ваши очки: " .. GetPoints(ply))
+        return ""
+    end
+
+    if command == "!shop" then
+        ply:ConCommand("points_shop")
+        return ""
+    end
+
+    if command == "!adminpoints" then
+        if not IsPlayerAdmin(ply) then
+            ply:ChatPrint("Только для администраторов")
+            return ""
+        end
+
+        ply:ConCommand("points_admin")
         return ""
     end
 end)


### PR DESCRIPTION
### Motivation
- Provide a way for players to spend earned points on default Half-Life 2 / Garry's Mod weapons and allow server admins to view and manage player point balances. 
- Improve UX by adding client-side UIs for a personal points menu, a weapon shop, and an admin control panel.

### Description
- Added a server-side weapon catalog and purchase flow in `lua/autorun/sv_points.lua`, including network strings for shop purchases and admin operations, validations for weapon availability, price checks, and point deduction/refund logic. 
- Implemented admin endpoints to fetch player lists and adjust points (`PointsAdminRequestPlayers`, `PointsAdminAdjustPoints`) with permission checks and immediate synchronization to clients. 
- Built client UIs in `lua/autorun/cl_points.lua` for the personal points popup (`points_menu`), weapon shop (`points_shop`) and admin panel (`points_admin`), including shop purchasing UI, admin per-player rows (`+/-/Set`), and a live points label update mechanism. 
- Updated `README.md` with features, usage commands, and a simple development check using `luac -p`, and fixed `AddCSLuaFile` path usage to `autorun/cl_points.lua`.

### Testing
- Performed Lua syntax checks with `luac -p lua/autorun/sv_points.lua` and `luac -p lua/autorun/cl_points.lua`, both succeeded. 
- Verified the client script UI refresh timer naming and admin list networking logic by static inspection and local validation, with no syntax errors reported. 
- Confirmed changes staged and included in the PR description for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac60fa06208332aca0235e10d79508)