### PR TITLE
Win95-style VGUI + admin bulk point actions

### DIFF
--- a/lua/autorun/cl_points.lua
+++ b/lua/autorun/cl_points.lua
@@ -18,6 +18,97 @@ local cachedPoints = 0
 local adminScroll
 local adminFrame
 
+local WIN95 = {
+    bg = Color(192, 192, 192),
+    dark = Color(64, 64, 64),
+    black = Color(0, 0, 0),
+    light = Color(223, 223, 223),
+    white = Color(255, 255, 255),
+    titleBlue = Color(10, 36, 106),
+    titleText = Color(255, 255, 255)
+}
+
+local function ApplyWin95Frame(frame)
+    frame:ShowCloseButton(false)
+    frame.btnMinim:SetVisible(false)
+    frame.btnMaxim:SetVisible(false)
+    frame:SetDraggable(true)
+
+    local closeBtn = vgui.Create("DButton", frame)
+    closeBtn:SetSize(22, 20)
+    closeBtn:SetText("X")
+    closeBtn:SetFont("DermaDefaultBold")
+    closeBtn:SetTextColor(WIN95.black)
+    closeBtn:DockPadding(0, 0, 0, 0)
+
+    function closeBtn:DoClick()
+        frame:Close()
+    end
+
+    function closeBtn:PerformLayout()
+        self:SetPos(frame:GetWide() - 28, 5)
+    end
+
+    function closeBtn:Paint(w, h)
+        draw.RoundedBox(0, 0, 0, w, h, WIN95.bg)
+        surface.SetDrawColor(WIN95.white)
+        surface.DrawLine(0, 0, w - 1, 0)
+        surface.DrawLine(0, 0, 0, h - 1)
+        surface.SetDrawColor(WIN95.black)
+        surface.DrawLine(0, h - 1, w - 1, h - 1)
+        surface.DrawLine(w - 1, 0, w - 1, h - 1)
+        return true
+    end
+
+    function frame:Paint(w, h)
+        draw.RoundedBox(0, 0, 0, w, h, WIN95.bg)
+
+        surface.SetDrawColor(WIN95.white)
+        surface.DrawLine(0, 0, w - 1, 0)
+        surface.DrawLine(0, 0, 0, h - 1)
+        surface.SetDrawColor(WIN95.black)
+        surface.DrawLine(0, h - 1, w - 1, h - 1)
+        surface.DrawLine(w - 1, 0, w - 1, h - 1)
+
+        draw.RoundedBox(0, 2, 2, w - 4, 24, WIN95.titleBlue)
+        draw.SimpleText(self:GetTitle(), "DermaDefaultBold", 8, 14, WIN95.titleText, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+    end
+end
+
+local function ApplyWin95Button(button)
+    button:SetTextColor(WIN95.black)
+
+    function button:Paint(w, h)
+        local col = WIN95.bg
+        if self:IsDown() then
+            col = Color(170, 170, 170)
+        elseif self:IsHovered() then
+            col = Color(205, 205, 205)
+        end
+
+        draw.RoundedBox(0, 0, 0, w, h, col)
+        surface.SetDrawColor(WIN95.white)
+        surface.DrawLine(0, 0, w - 1, 0)
+        surface.DrawLine(0, 0, 0, h - 1)
+        surface.SetDrawColor(WIN95.dark)
+        surface.DrawLine(0, h - 1, w - 1, h - 1)
+        surface.DrawLine(w - 1, 0, w - 1, h - 1)
+        return true
+    end
+end
+
+local function ApplyWin95Panel(panel)
+    function panel:Paint(w, h)
+        draw.RoundedBox(0, 0, 0, w, h, WIN95.bg)
+        surface.SetDrawColor(WIN95.white)
+        surface.DrawLine(0, 0, w - 1, 0)
+        surface.DrawLine(0, 0, 0, h - 1)
+        surface.SetDrawColor(WIN95.dark)
+        surface.DrawLine(0, h - 1, w - 1, h - 1)
+        surface.DrawLine(w - 1, 0, w - 1, h - 1)
+    end
+end
+
 net.Receive("PointsResponse", function()
     local msg = net.ReadString()
     chat.AddText(Color(0, 255, 0), msg)
@@ -57,10 +148,13 @@ local function ShowPointsPopup()
     frame:Center()
     frame:SetTitle("Получить очки")
     frame:MakePopup()
+    ApplyWin95Frame(frame)
 
     local button = vgui.Create("DButton", frame)
     button:Dock(FILL)
+    button:DockMargin(8, 32, 8, 8)
     button:SetText("Получить 10 очков")
+    ApplyWin95Button(button)
 
     function button:DoClick()
         net.Start("RequestPoints")
@@ -75,9 +169,11 @@ local function ShowPointsMenu()
     frame:Center()
     frame:SetTitle("Мои очки")
     frame:MakePopup()
+    ApplyWin95Frame(frame)
 
     pointsLabel = vgui.Create("DLabel", frame)
     pointsLabel:Dock(FILL)
+    pointsLabel:DockMargin(8, 32, 8, 8)
     pointsLabel:SetContentAlignment(5)
     pointsLabel:SetText("Загрузка...")
 
@@ -90,10 +186,13 @@ local function ShowShopMenu()
     frame:Center()
     frame:SetTitle("Магазин оружия")
     frame:MakePopup()
+    ApplyWin95Frame(frame)
 
     local topPanel = vgui.Create("DPanel", frame)
     topPanel:Dock(TOP)
     topPanel:SetTall(35)
+    topPanel:DockMargin(8, 32, 8, 4)
+    ApplyWin95Panel(topPanel)
 
     local pointsInfo = vgui.Create("DLabel", topPanel)
     pointsInfo:Dock(FILL)
@@ -102,12 +201,14 @@ local function ShowShopMenu()
 
     local scroll = vgui.Create("DScrollPanel", frame)
     scroll:Dock(FILL)
+    scroll:DockMargin(8, 0, 8, 8)
 
     for _, weapon in ipairs(SHOP_WEAPONS) do
         local row = vgui.Create("DPanel", scroll)
         row:Dock(TOP)
         row:DockMargin(5, 5, 5, 0)
         row:SetTall(40)
+        ApplyWin95Panel(row)
 
         local label = vgui.Create("DLabel", row)
         label:Dock(LEFT)
@@ -123,6 +224,7 @@ local function ShowShopMenu()
         local buyButton = vgui.Create("DButton", row)
         buyButton:Dock(FILL)
         buyButton:SetText("Купить")
+        ApplyWin95Button(buyButton)
 
         function buyButton:DoClick()
             net.Start("PointsShopBuyWeapon")
@@ -152,6 +254,7 @@ local function BuildAdminPlayerRow(parent, data, refreshFn)
     row:Dock(TOP)
     row:DockMargin(5, 5, 5, 0)
     row:SetTall(66)
+    ApplyWin95Panel(row)
 
     local infoLabel = vgui.Create("DLabel", row)
     infoLabel:Dock(LEFT)
@@ -168,6 +271,7 @@ local function BuildAdminPlayerRow(parent, data, refreshFn)
     addBtn:Dock(LEFT)
     addBtn:SetWide(45)
     addBtn:SetText("+")
+    ApplyWin95Button(addBtn)
     function addBtn:DoClick()
         net.Start("PointsAdminAdjustPoints")
         net.WriteEntity(data.entity)
@@ -181,6 +285,7 @@ local function BuildAdminPlayerRow(parent, data, refreshFn)
     subBtn:Dock(LEFT)
     subBtn:SetWide(45)
     subBtn:SetText("-")
+    ApplyWin95Button(subBtn)
     function subBtn:DoClick()
         net.Start("PointsAdminAdjustPoints")
         net.WriteEntity(data.entity)
@@ -193,6 +298,7 @@ local function BuildAdminPlayerRow(parent, data, refreshFn)
     local setBtn = vgui.Create("DButton", row)
     setBtn:Dock(FILL)
     setBtn:SetText("Set")
+    ApplyWin95Button(setBtn)
     function setBtn:DoClick()
         net.Start("PointsAdminAdjustPoints")
         net.WriteEntity(data.entity)
@@ -214,14 +320,44 @@ local function ShowAdminMenu()
     frame:Center()
     frame:SetTitle("Админ панель очков")
     frame:MakePopup()
+    ApplyWin95Frame(frame)
+
+    local actions = vgui.Create("DPanel", frame)
+    actions:Dock(TOP)
+    actions:SetTall(70)
+    actions:DockMargin(8, 32, 8, 4)
+    actions:DockPadding(6, 6, 6, 6)
+    ApplyWin95Panel(actions)
+
+    local allEntry = vgui.Create("DTextEntry", actions)
+    allEntry:Dock(LEFT)
+    allEntry:SetWide(70)
+    allEntry:SetNumeric(true)
+    allEntry:SetText("5")
+
+    local addAllBtn = vgui.Create("DButton", actions)
+    addAllBtn:Dock(LEFT)
+    addAllBtn:DockMargin(6, 0, 6, 0)
+    addAllBtn:SetWide(185)
+    addAllBtn:SetText("+ всем игрокам")
+    ApplyWin95Button(addAllBtn)
+
+    local resetAllBtn = vgui.Create("DButton", actions)
+    resetAllBtn:Dock(LEFT)
+    resetAllBtn:SetWide(185)
+    resetAllBtn:SetText("Сбросить всем в 0")
+    ApplyWin95Button(resetAllBtn)
 
     local refreshBtn = vgui.Create("DButton", frame)
     refreshBtn:Dock(TOP)
     refreshBtn:SetTall(32)
+    refreshBtn:DockMargin(8, 0, 8, 4)
     refreshBtn:SetText("Обновить список")
+    ApplyWin95Button(refreshBtn)
 
     local scroll = vgui.Create("DScrollPanel", frame)
     scroll:Dock(FILL)
+    scroll:DockMargin(8, 0, 8, 8)
     adminFrame = frame
     adminScroll = scroll
 
@@ -232,6 +368,22 @@ local function ShowAdminMenu()
 
     function refreshBtn:DoClick()
         requestList()
+    end
+
+    function addAllBtn:DoClick()
+        net.Start("PointsAdminMassAction")
+        net.WriteString("add_all")
+        net.WriteInt(tonumber(allEntry:GetValue()) or 0, 32)
+        net.SendToServer()
+        timer.Simple(0.2, requestList)
+    end
+
+    function resetAllBtn:DoClick()
+        net.Start("PointsAdminMassAction")
+        net.WriteString("reset_all")
+        net.WriteInt(0, 32)
+        net.SendToServer()
+        timer.Simple(0.2, requestList)
     end
 
     requestList()

--- a/lua/autorun/sv_points.lua
+++ b/lua/autorun/sv_points.lua
@@ -26,6 +26,7 @@ util.AddNetworkString("PointsShopPurchaseResult")
 util.AddNetworkString("PointsAdminRequestPlayers")
 util.AddNetworkString("PointsAdminPlayersData")
 util.AddNetworkString("PointsAdminAdjustPoints")
+util.AddNetworkString("PointsAdminMassAction")
 
 local function GetPoints(ply)
     return PlayerPoints[ply:SteamID()] or 0
@@ -182,6 +183,46 @@ net.Receive("PointsAdminAdjustPoints", function(_, ply)
     net.WriteString(target:SteamID())
     net.WriteInt(newValue, 32)
     net.Send(ply)
+end)
+
+
+net.Receive("PointsAdminMassAction", function(_, ply)
+    if not IsPlayerAdmin(ply) then
+        SendPointsMessage(ply, "Недостаточно прав")
+        return
+    end
+
+    local action = net.ReadString()
+    local amount = math.floor(net.ReadInt(32))
+
+    if action ~= "add_all" and action ~= "reset_all" then
+        SendPointsMessage(ply, "Неизвестное массовое действие")
+        return
+    end
+
+    if action == "add_all" and math.abs(amount) > 100000 then
+        SendPointsMessage(ply, "Слишком большое значение")
+        return
+    end
+
+    for _, target in ipairs(player.GetAll()) do
+        local oldValue = GetPoints(target)
+        if action == "reset_all" then
+            SetPoints(target, 0)
+            SendPointsMessage(target, "Администратор сбросил ваши очки")
+        else
+            SetPoints(target, oldValue + amount)
+            SendPointsMessage(target, "Администратор изменил ваши очки на " .. amount)
+        end
+
+        SendCurrentPoints(target)
+    end
+
+    if action == "reset_all" then
+        SendPointsMessage(ply, "Очки всех игроков сброшены")
+    else
+        SendPointsMessage(ply, "Очки всех игроков изменены на " .. amount)
+    end
 end)
 
 hook.Add("PlayerSay", "PointsChatCommand", function(ply, text)


### PR DESCRIPTION
### Motivation
- Restyle the points UI to a Windows 95 look and add at least two new admin functions to manage player points in bulk.

### Description
- Added a `WIN95` color palette and helper functions `ApplyWin95Frame`, `ApplyWin95Button`, and `ApplyWin95Panel` and applied them across the client UI in `lua/autorun/cl_points.lua` (popup, points window, shop, admin rows/buttons).
- Extended the admin panel UI with a new action strip that includes `+ всем игрокам` (add to all players) and `Сбросить всем в 0` (reset all players to 0) and wired the buttons to send `PointsAdminMassAction` messages.
- Added server networking via `util.AddNetworkString("PointsAdminMassAction")` and implemented a handler in `lua/autorun/sv_points.lua` that supports `add_all` and `reset_all` operations with admin checks and input validation.

### Testing
- Performed a Lua syntax/load check with `lua -e "assert(loadfile('lua/autorun/cl_points.lua')); assert(loadfile('lua/autorun/sv_points.lua')); print('lua syntax ok')"` which printed `lua syntax ok` indicating successful loading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6732842c8332abd695f17e3d7bef)